### PR TITLE
Update docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
       - data:/data/db
       - ./mongo/mongod.conf:/etc/mongo/mongod.conf
     ports:
-      - 27017:27017
+      - 127.0.0.1:27017:27017
     command: mongod --config /etc/mongo/mongod.conf
 
   mongo-express:


### PR DESCRIPTION
Previously I could access mongodb via 27017 port from the internet. Now this port is closed